### PR TITLE
Use repr(transparent) for wrapper structs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ macro_rules! wrapper_impls {
 macro_rules! wrapper_type {
     ($name:ident, $typ:ty) => {
         #[derive(Clone)]
-        #[repr(C)]
+        #[repr(transparent)]
         pub struct $name {
             internal: $typ,
         }
@@ -104,7 +104,7 @@ macro_rules! wrapper_type {
 
 macro_rules! wrapper_type_no_clone {
     ($name:ident, $typ:ty) => {
-        #[repr(C)]
+        #[repr(transparent)]
         pub struct $name {
             internal: $typ,
         }
@@ -3777,6 +3777,7 @@ impl Buffer {
 
 // =============================================================================================
 
+#[repr(transparent)]
 pub struct Context {
     internal: nk_context,
 }


### PR DESCRIPTION
`repr(transparent)` provides stronger guarantees that the struct will have the exact same representation as its only field. And `Context` didn't even *have* an explicit representation, not even `repr(C)`!!

Because of all the transmutation that this library does between wrapper types and the types that they wrap, those guarantees are quite important, don't you think? :)